### PR TITLE
Fix clear msg and parseSubject

### DIFF
--- a/src/main/java/seedu/edudex/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/edudex/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.edudex.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "EduDex has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/edudex/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/edudex/logic/parser/ParserUtil.java
@@ -165,11 +165,11 @@ public class ParserUtil {
      */
     public static Subject parseSubjectName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim();
-        if (trimmedName.isEmpty() || !Subject.isValidSubjectName(trimmedName)) {
+        String trimConsecutiveWhiteSpaces = name.replaceAll("\\s+", " ").trim();
+        if (trimConsecutiveWhiteSpaces.isEmpty() || !Subject.isValidSubjectName(trimConsecutiveWhiteSpaces)) {
             throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
         }
-        return new Subject(trimmedName);
+        return new Subject(trimConsecutiveWhiteSpaces);
     }
 
     /**


### PR DESCRIPTION
Changes made

- Update parseSubjectName to trim consecutive whitespaces and replace with 1 white space 
Fixes `addlesson higher  chinese` and `addsub higher  chinese` now the same as  `addlesson higher chinese` and 
`addsub higher chinese` 

editlesson works as intended 

- Update clear command message 

closes #246 
closes #270 

might fix #274 